### PR TITLE
Remove extraneous push in Release task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,7 +28,7 @@ task :release do
   host = "https://#{ENV['BUNDLE_GEMS__WEBLINC__COM']}@gems.weblinc.com"
 
   system "git tag -a v#{Workarea::FilterDropdowns::VERSION} -m 'Tagging #{Workarea::FilterDropdowns::VERSION}'"
-  system 'git push --tags'
+  system 'git push origin HEAD --follow-tags'
 
   system 'gem build workarea-filter_dropdowns.gemspec'
   system "gem push workarea-filter_dropdowns-#{Workarea::FilterDropdowns::VERSION}.gem --host #{host}"

--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,7 @@ end
 APP_RAKEFILE = File.expand_path('../test/dummy/Rakefile', __FILE__)
 load 'rails/tasks/engine.rake'
 load 'rails/tasks/statistics.rake'
+load 'workarea/changelog.rake'
 require 'rake/testtask'
 
 Rake::TestTask.new(:test) do |t|
@@ -26,6 +27,10 @@ require 'workarea/filter_dropdowns/version'
 desc "Release version #{Workarea::FilterDropdowns::VERSION} of the gem"
 task :release do
   host = "https://#{ENV['BUNDLE_GEMS__WEBLINC__COM']}@gems.weblinc.com"
+
+  Rake::Task['workarea:changelog'].execute
+  system 'git add CHANGELOG.md'
+  system 'git commit -m "Update CHANGELOG"'
 
   system "git tag -a v#{Workarea::FilterDropdowns::VERSION} -m 'Tagging #{Workarea::FilterDropdowns::VERSION}'"
   system 'git push origin HEAD --follow-tags'


### PR DESCRIPTION
We're running out of minutes in our GitHub actions due to duplicate pushes
during a release. This consolidates the two pushes into one.

No changelog

WORKAREA-148